### PR TITLE
chore: Favor secret name "github-token" over "test"

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@
 
 ### GithubCustomResource <a name="GithubCustomResource" id="@pepperize/cdk-github.GithubCustomResource"></a>
 
-```typescript const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+```typescript const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
 
 new GithubCustomResource(scope, "GithubRepo", {
    onCreate: {

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ yarn build
 6. Import your secret
 
    ```typescript
-   const secret = secrets_manager.Secret.fromSecretNameV2(stack, "Auth", "cdk-github/test");
+   const secret = secrets_manager.Secret.fromSecretNameV2(stack, "Auth", "cdk-github/github-token");
    ```
 
 7. Configure GitHub App authenticate as an installation
@@ -167,7 +167,7 @@ Lookup the secret in your AWS CDK app:
 
 ```typescript
 // 👇Lookup your secret containing the AuthOptions
-const secret = secrets_manager.Secret.fromSecretNameV2(stack, "Auth", "cdk-github/test");
+const secret = secrets_manager.Secret.fromSecretNameV2(stack, "Auth", "cdk-github/github-token");
 // 👇This will send the secret arn to the custom resource handler
 const authOptions = AuthOptions.appAuth(secret);
 ```
@@ -190,7 +190,7 @@ Just add your PAT to an SSM StringParameter
 
 ```typescript
 // 👇Lookup your parameter containing the TOKEN
-const parameter = ssm.StringParameter.fromStringParameterName(stack, "Auth", "cdk-github/test");
+const parameter = ssm.StringParameter.fromStringParameterName(stack, "Auth", "cdk-github/github-token");
 // 👇This will send the parameter arn to the custom resource handler
 const authOptions = AuthOptions.tokenAuth(parameter);
 ```
@@ -209,7 +209,7 @@ const authOptions = AuthOptions.unauthenticated();
 [@octokit/plugin-rest-endpoint-methods](https://github.com/octokit/plugin-rest-endpoint-methods.js/#usage)
 
 ```typescript
-const auth = secrets_manager.Secret.fromSecretNameV2(stack, "Auth", "cdk-github/test");
+const auth = secrets_manager.Secret.fromSecretNameV2(stack, "Auth", "cdk-github/github-token");
 
 const repo = new GithubCustomResource(stack, "GithubRepo", {
   onCreate: {
@@ -260,7 +260,7 @@ Manages an environment secret. Will fetch the source AWS SecretsManager secret a
 
 ```typescript
 // 👇The GitHub API authentication secret
-const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
 
 // 👇The AWS SecretsManager Secret to configure as GitHub Action secret.
 const secret = secrets_manager.Secret.fromSecretNameV2(scope, "Secret", "any-secret/example");
@@ -289,7 +289,7 @@ Manage an GitHib Actions organization secret. Will fetch the source AWS SecretsM
 
 ```typescript
 // 👇The GitHub API authentication secret
-const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
 
 // 👇The AWS SecretsManager Secret to configure as GitHub Action secret.
 const secret = secrets_manager.Secret.fromSecretNameV2(scope, "Secret", "any-secret/example");
@@ -315,7 +315,7 @@ Manage an GitHib Actions Repository secret. Will fetch the source AWS SecretsMan
 
 ```typescript
 // 👇The GitHub API authentication secret
-const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
 
 // 👇The AWS SecretsManager Secret to configure as GitHub Action secret.
 const secret = secrets_manager.Secret.fromSecretNameV2(scope, "Secret", "any-secret/example");

--- a/src/custom-resource-provider/handler.lambda.ts
+++ b/src/custom-resource-provider/handler.lambda.ts
@@ -56,8 +56,6 @@ export const handler: OnEventHandler = async (event: OnEventRequest): Promise<On
   const octokit = new Octokit(octokitOptions);
 
   try {
-    // https://github.com/octokit/plugin-rest-endpoint-methods.js/#usage
-    // @ts-ignore
     const response = await executeGithubApiCall(octokit, call);
 
     console.debug("Response: %j", response);

--- a/src/github-actions-secret-environment.ts
+++ b/src/github-actions-secret-environment.ts
@@ -33,7 +33,7 @@ export interface GithubActionsSecretEnvironmentProps extends GithubCustomResourc
  *
  * ```typescript
  * // The GitHub API authentication secret
- * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+ * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
  *
  * // The AWS SecretsManager Secret to configure as GitHub Action secret.
  * const secret = secrets_manager.Secret.fromSecretNameV2(scope, "Secret", "any-secret/example");

--- a/src/github-actions-secret-organization.ts
+++ b/src/github-actions-secret-organization.ts
@@ -39,7 +39,7 @@ export interface GithubActionsSecretOrganizationProps extends GithubCustomResour
  *
  * ```typescript
  * // The GitHub API authentication secret
- * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+ * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
  *
  * // The AWS SecretsManager Secret to configure as GitHub Action secret.
  * const secret = secrets_manager.Secret.fromSecretNameV2(scope, "Secret", "any-secret/example");

--- a/src/github-actions-secret-repository.ts
+++ b/src/github-actions-secret-repository.ts
@@ -33,7 +33,7 @@ export interface GithubActionsSecretRepositoryProps extends GithubCustomResource
  *
  * ```typescript
  * // The GitHub API authentication secret
- * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+ * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
  *
  * // The AWS SecretsManager Secret to configure as GitHub Action secret.
  * const secret = secrets_manager.Secret.fromSecretNameV2(scope, "Secret", "any-secret/example");

--- a/src/github-custom-resource.ts
+++ b/src/github-custom-resource.ts
@@ -121,7 +121,7 @@ export abstract class GithubCustomResourceBase extends Construct {
 
 /**
  * ```typescript
- * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/test");
+ * const auth = secrets_manager.Secret.fromSecretNameV2(scope, "Auth", "cdk-github/github-token");
  *
  * new GithubCustomResource(scope, "GithubRepo", {
  *   onCreate: {


### PR DESCRIPTION
Like discussed in https://github.com/pepperize/cdk-github/pull/53#issuecomment-1416802967.

I've left `integ.default.ts` untouched, as this might require you to change your resources in your aws account (and its not purely docs there).

