### PR TITLE
chore: Upgrade from node14 to node16

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -56,7 +56,7 @@
       "description": "Create a JavaScript bundle from src/custom-resource-provider/handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/custom-resource-provider/handler.lambda.ts --target=\"node14\" --platform=\"node\" --outfile=\"assets/custom-resource-provider/handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:aws-sdk"
+          "exec": "esbuild --bundle src/custom-resource-provider/handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/custom-resource-provider/handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:aws-sdk"
         }
       ]
     },
@@ -65,7 +65,7 @@
       "description": "Continuously update the JavaScript bundle from src/custom-resource-provider/handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/custom-resource-provider/handler.lambda.ts --target=\"node14\" --platform=\"node\" --outfile=\"assets/custom-resource-provider/handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:aws-sdk --watch"
+          "exec": "esbuild --bundle src/custom-resource-provider/handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/custom-resource-provider/handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:aws-sdk --watch"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,6 @@
 import { AwsCdkConstructLibrary } from "@pepperize/projen-awscdk-construct";
-import { javascript } from "projen";
+import { javascript, awscdk } from "projen";
+
 const project = new AwsCdkConstructLibrary({
   author: "Patrick Florek",
   authorAddress: "patrick.florek@gmail.com",
@@ -72,6 +73,10 @@ const project = new AwsCdkConstructLibrary({
   gitpod: true,
 
   gitignore: ["cdk.out"],
+
+  lambdaOptions: {
+    runtime: awscdk.LambdaRuntime.NODEJS_16_X,
+  },
 });
 
 project.eslint?.allowDevDeps("src/custom-resource-provider/encrypt.ts");

--- a/src/custom-resource-provider/handler-function.ts
+++ b/src/custom-resource-provider/handler-function.ts
@@ -17,7 +17,7 @@ export class HandlerFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/custom-resource-provider/handler.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/custom-resource-provider/handler.lambda')),
     });

--- a/test/__snapshots__/github-custom-resource.test.ts.snap
+++ b/test/__snapshots__/github-custom-resource.test.ts.snap
@@ -54,7 +54,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 600,
       },
       "Type": "AWS::Lambda::Function",


### PR DESCRIPTION
Upgrade the provided handler function to node 16 (since pretty soon, node 14 doesnt get any security updates anymore, see https://endoflife.date/nodejs).


The provided projen version doesnt support the node 18 yet, which most likely would be a better upgrade (but additional changes would be needed as we rely on aws-sdk v2 and node 18 ships with aws-sdk v3).

If we want to go to node 18:
We would need to upgrade projen to at least [v0.65.56](https://github.com/projen/projen/releases/tag/v0.65.56) which would include the change (or [v0.67.2](https://github.com/projen/projen/releases/tag/v0.67.2) which includes a bugfix, or even just the latest version 😄 ). 

